### PR TITLE
Update pre-commit-hook.sh and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Resharper format pre-commit hook. It uses resharper to format all the files you'
 # Installation
 Get the latest version using bash, by running this command in the root of your repository:
 ```bash
-curl -s https://raw.githubusercontent.com/GeeWee/reshaper-pre-commit-hook/master/install-git-hook.sh | sh
+curl -s https://raw.githubusercontent.com/GeeWee/reshaper-pre-commit-hook/master/install-git-hook.sh | sh (or bash, depending on your system)
 ```
 Note that this runs a shell script on your computer. You might want to review the script before running it.
 

--- a/pre-commit-hook.sh
+++ b/pre-commit-hook.sh
@@ -44,4 +44,3 @@ echo "Restaging files: $STAGED_FILES"
 echo ${STAGED_FILES} | xargs -t -l git add
 
 echo "pre-commit hook finished"
-

--- a/pre-commit-hook.sh
+++ b/pre-commit-hook.sh
@@ -27,14 +27,15 @@ fi
 
 # Edit your project files here
 echo "Formatting files..."
+SOLUTION_FILE=$(find . -type f -name "*.sln")
 if [[ "$OSTYPE" == "msys"* ]]; then
     # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
-    ./.git/hooks/resharper/cleanupcode.exe --profile="Built-in: Reformat Code" ./OAI.sln --include="$INCLUDE_STRING"
+    ./.git/hooks/resharper/cleanupcode.exe --profile="Built-in: Reformat Code" $SOLUTION_FILE --include="$INCLUDE_STRING"
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     #Cygwin terminal emulator
-    ./.git/hooks/resharper/cleanupcode.exe --profile="Built-in: Reformat Code" ./OAI.sln --include="$INCLUDE_STRING"
+    ./.git/hooks/resharper/cleanupcode.exe --profile="Built-in: Reformat Code" $SOLUTION_FILE --include="$INCLUDE_STRING"
 else
-    sh ./.git/hooks/resharper/cleanupcode.sh --profile="Built-in: Reformat Code" ./OAI.sln --include="$INCLUDE_STRING"
+    sh ./.git/hooks/resharper/cleanupcode.sh --profile="Built-in: Reformat Code" $SOLUTION_FILE --include="$INCLUDE_STRING"
 fi
 
 

--- a/pre-commit-hook.sh
+++ b/pre-commit-hook.sh
@@ -44,3 +44,4 @@ echo "Restaging files: $STAGED_FILES"
 echo ${STAGED_FILES} | xargs -t -l git add
 
 echo "pre-commit hook finished"
+


### PR DESCRIPTION
Stores solution filename to a variable and uses it instead of the hardcoded OAI.sln